### PR TITLE
Hardcode the URL to flex 0.6.0 binaries - they are no longer in the mirrors

### DIFF
--- a/dependencies/ApacheFalcon.js
+++ b/dependencies/ApacheFalcon.js
@@ -168,8 +168,9 @@ ApacheFalcon.handleFalconMirrorsResponse = function (error, response, body)
     if (!error && response.statusCode == 200)
     {
         var mirrors = JSON.parse(body);
-        var falconPreferredDownloadURL = mirrors.preferred + pathToFalconBinary + fileNameFalconBinary;
-        console.log('Downloading Apache Flex Falcon Compiler');
+        //var falconPreferredDownloadURL = mirrors.preferred + pathToFalconBinary + fileNameFalconBinary;
+        var falconPreferredDownloadURL = 'http://archive.apache.org/dist/flex/falcon/0.6.0/binaries/apache-flex-falconjx-0.6.0-bin.zip';
+        console.log('Downloading Apache Flex Falcon Compiler from ' + falconPreferredDownloadURL);
         request
             .get(falconPreferredDownloadURL)
             .pipe(fs.createWriteStream(constants.DOWNLOADS_FOLDER + fileNameFalconBinary)

--- a/dependencies/ApacheFlexJS.js
+++ b/dependencies/ApacheFlexJS.js
@@ -37,8 +37,9 @@ ApacheFlexJS.handleFlexJSMirrorsResponse = function (error, response, body)
     if (!error && response.statusCode == 200)
     {
         var mirrors = JSON.parse(body);
-        var flexJSPreferredDownloadURL = mirrors.preferred + pathToFlexJSBinary + fileNameFlexJSBinary;
-        console.log('Downloading Apache FlexJS');
+        //var flexJSPreferredDownloadURL = mirrors.preferred + pathToFlexJSBinary + fileNameFlexJSBinary;
+        var flexJSPreferredDownloadURL = 'http://archive.apache.org/dist/flex/flexjs/0.6.0/binaries/apache-flex-flexjs-0.6.0-bin.zip'
+        console.log('Downloading Apache FlexJS from ' + flexJSPreferredDownloadURL);
         request
             .get(flexJSPreferredDownloadURL)
             .pipe(fs.createWriteStream(constants.DOWNLOADS_FOLDER + fileNameFlexJSBinary)


### PR DESCRIPTION
This fixes the broken WeaveJS build by hardcoding the downloads for Apache Falcon and Apache FlexJS to the 0.6.0 versions that can be found in the Apache archives. The fundamental cause of the broken build was that 0.6.0 disappeared from the mirrors.

An ultimate fix may be to upgrade the versions of falcon and flexjs used by WeaveJS, but I'm not sure that is worth the effort if the ultimate goal is to eliminate the dependency on these tools.